### PR TITLE
[fix] adjust render size to match report

### DIFF
--- a/setup/rescalePhotos.js
+++ b/setup/rescalePhotos.js
@@ -56,13 +56,13 @@ var renders = [
     },
 
     // Print Versions
-    // 3.5" x 5" @ 300dpi:
-    // 1500x1050
+    // 2.45" x 3.5" @ 300dpi:
+    // 1050x735
     {
         name: '_print',
         quality:60,
-        width: 1500,
-        height: 1050,
+        width: 1050,
+        height: 735,
         'default':false
     }
 ]


### PR DESCRIPTION
This reduces the render to a size that is closer to what the report is using. This hopefully will allow the report to complete without errors.